### PR TITLE
Add peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "@opentelemetry/api": "^0.13.0",
     "fastify-plugin": "^3.0.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/context-async-hooks": "^0.13.0",
+    "@opentelemetry/core": "^0.13.0",
+    "@opentelemetry/tracing": "^0.13.0"
+  },
   "lint-staged": {
     "*.{js,jsx}": [
       "npm run fix"


### PR DESCRIPTION
This will warn if a user of this module updates this module without updating the needed `@opentelemetry/*` modules to a compatible version, which can otherwise be easily missed