### PR TITLE
feat: wrapRoutes and ignoreRoutes plugin options.

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -2,26 +2,38 @@
 require('./opentelemetry')
 
 const fastify = require('fastify')
-const fastifyOpentelemetry = require('../')
+const fastifyOpentelemetry = require('..')
 
 const app = fastify()
 
-app.register(fastifyOpentelemetry, { serviceName: 'basic-example' })
+app.register(fastifyOpentelemetry, { serviceName: 'basic-example', wrapRoutes: true })
 
-app.get('/', {}, async (request, reply) => {
+app.decorateReply('doingWork', async () => 'done')
+
+app.get('/', async function routeHandler (request, reply) {
   const {
-    activeSpan,
     tracer
   } = request.openTelemetry()
 
-  tracer.withSpan(activeSpan, () => {
-    const span = tracer.getCurrentSpan()
-    if (span) {
-      span.addEvent('Doing Work')
-    }
-  })
+  // Spans started in a wrapped route will automatically be children of the activeSpan.
+  const childSpan = tracer.startSpan('reply.doingWork')
+  try {
+    const result = await reply.doingWork('arg1', 123)
+    childSpan.setAttributes({
+      calledWith: '"arg1", 123',
+      returned: result
+    })
+  } catch (error) {
+    // fastify-opentelemetry automatically adds Error data to the parent spans attributes.
+    return error
+  } finally {
+    // Always be sure to end child spans. Using a `finally` block ensures the span will also end if there's an error.
+    childSpan.end()
+  }
 
-  reply.send('Fastify OpenTelemetry Example App')
+  reply.type('text/html')
+
+  return '<h1>Fastify OpenTelemetry Example App</h1>'
 })
 
 const PORT = process.env.PORT || 3000

--- a/test/fixtures/openTelemetryApi.js
+++ b/test/fixtures/openTelemetryApi.js
@@ -1,11 +1,12 @@
 const { stub } = require('sinon')
 
 const {
-  propagation,
-  trace,
+  context,
   NOOP_SPAN,
   NOOP_TRACER,
-  NOOP_TRACER_PROVIDER
+  NOOP_TRACER_PROVIDER,
+  propagation,
+  trace
 } = require('@opentelemetry/api')
 
 stub(NOOP_SPAN, 'end')
@@ -20,11 +21,14 @@ stub(trace, 'getTracer').returns(NOOP_TRACER)
 stub(propagation, 'extract').callThrough()
 stub(propagation, 'inject').callThrough()
 
+stub(context, 'with').callThrough()
+
 trace.setGlobalTracerProvider(NOOP_TRACER_PROVIDER)
 
 module.exports = {
   STUB_SPAN: NOOP_SPAN,
   STUB_TRACER: NOOP_TRACER,
   STUB_TRACE_API: trace,
-  STUB_PROPAGATION_API: propagation
+  STUB_PROPAGATION_API: propagation,
+  STUB_CONTEXT_API: context
 }


### PR DESCRIPTION
### Summary
- Add `wrapRoutes` option.
- Add `ignoreRoutes` option.
- Change plugin and hooks to async.
- Remove support for Fastify v2. (Breaking - if not using Fastify v3)

### Test plan
- Run the example -> `npm run dev`
- Navigate to http://localhost:3000
- Check your terminal logs - the `reply.doingWork` span's `parentId` should be the `id` of the `basic-example - GET - /` span.