### PR TITLE
feat: Update to @opentelemetry/api v0.15.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ provider.register({
 })
 
 // Note: the above is just a basic example. fastify-opentelemetry is compatible with any
-// @opentelemetry/api(0.14.0) configuration.
+// @opentelemetry/api(0.15.0) configuration.
 ```
 
 
@@ -156,8 +156,9 @@ This plugin registers the following Fastify hooks:
  - `onRoute`: Added only if `wrapRoutes` is enabled.
 
  #### OpenTelemetry Compatibility
-  As of version `0.6.0` this plugin is compatible with `@opentelemetry/api@0.14.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
+  As of version `0.8.0` this plugin is compatible with `@opentelemetry/api@0.15.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
 
+  - `@opentelemetry/api@0.14.0` -> `@autotelic/fastify-opentelemetry@0.7.0`
   - `@opentelemetry/api@0.13.0` -> `@autotelic/fastify-opentelemetry@0.5.0`
   - `@opentelemetry/api@0.12.0` -> `@autotelic/fastify-opentelemetry@0.4.0`
   - `@opentelemetry/api@0.10.0` -> `@autotelic/fastify-opentelemetry@0.2.4`

--- a/example/index.js
+++ b/example/index.js
@@ -38,7 +38,10 @@ app.get('/', async function routeHandler (request, reply) {
 
 const PORT = process.env.PORT || 3000
 
-app.listen(PORT, () => {
+app.listen(PORT, (error) => {
+  if (error) {
+    console.log(error)
+  }
   console.info(`
   *** Listening on Port: ${PORT} ***
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ const {
   context,
   defaultTextMapGetter,
   defaultTextMapSetter,
-  getActiveSpan,
+  getSpan,
   propagation,
-  setActiveSpan,
+  setSpan,
   StatusCode,
   trace
 } = require('@opentelemetry/api')
@@ -59,7 +59,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
     const request = this
     return {
       get activeSpan () {
-        return getActiveSpan(getContext(request))
+        return getSpan(getContext(request))
       },
       get context () {
         return getContext(request)
@@ -93,14 +93,14 @@ async function openTelemetryPlugin (fastify, opts = {}) {
       activeContext
     )
     span.setAttributes(formatSpanAttributes.request(request))
-    contextMap.set(request, setActiveSpan(activeContext, span))
+    contextMap.set(request, setSpan(activeContext, span))
   }
 
   async function onResponse (request, reply) {
     if (ignoreRoutes.includes(request.url)) return
 
     const activeContext = getContext(request)
-    const span = getActiveSpan(activeContext)
+    const span = getSpan(activeContext)
     const spanStatus = { code: StatusCode.OK }
 
     if (reply.statusCode >= 400) {
@@ -117,7 +117,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
     if (ignoreRoutes.includes(request.url)) return
 
     const activeContext = getContext(request)
-    const span = getActiveSpan(activeContext)
+    const span = getSpan(activeContext)
     span.setAttributes(formatSpanAttributes.error(error))
   }
 

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^0.14.0",
-    "@opentelemetry/core": "^0.14.0",
-    "@opentelemetry/tracing": "^0.14.0",
+    "@opentelemetry/context-async-hooks": "^0.15.0",
+    "@opentelemetry/core": "^0.15.0",
+    "@opentelemetry/tracing": "^0.15.0",
     "fastify": "^3.8.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
@@ -43,7 +43,7 @@
     "tap": "^14.11.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.14.0",
+    "@opentelemetry/api": "^0.15.0",
     "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,8 +3,8 @@ const { resetHistory } = require('sinon')
 const {
   defaultTextMapGetter,
   defaultTextMapSetter,
-  getActiveSpan,
-  setActiveSpan,
+  getSpan,
+  setSpan,
   ROOT_CONTEXT,
   StatusCode
 } = require('@opentelemetry/api')
@@ -153,7 +153,7 @@ test('should not decorate the request if exposeApi is false', async ({ is, teard
 })
 
 test('should be able to access context, activeSpan, extract, inject, and tracer via the request decorator', async ({ is, teardown }) => {
-  const dummyContext = setActiveSpan(ROOT_CONTEXT, STUB_SPAN)
+  const dummyContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
   const replyHeaders = { foo: 'bar' }
   async function routeHandler (request, reply) {
     const {
@@ -166,7 +166,7 @@ test('should be able to access context, activeSpan, extract, inject, and tracer 
     const newSpan = tracer.startSpan('newSpan', {}, extract(request.headers))
 
     activeSpan.setAttribute('foo', 'bar')
-    getActiveSpan(context).setAttribute('bar', 'foo')
+    getSpan(context).setAttribute('bar', 'foo')
 
     inject(replyHeaders)
     reply.headers(replyHeaders)
@@ -191,7 +191,7 @@ test('should be able to access context, activeSpan, extract, inject, and tracer 
 })
 
 test('should wrap all routes when wrapRoutes is true', async ({ same, teardown }) => {
-  const dummyContext = setActiveSpan(ROOT_CONTEXT, STUB_SPAN)
+  const dummyContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
 
   const fastify = require('fastify')()
 
@@ -220,7 +220,7 @@ test('should wrap all routes when wrapRoutes is true', async ({ same, teardown }
 })
 
 test('should only wrap routes provided in wrapRoutes array', async ({ same, is, teardown }) => {
-  const dummyContext = setActiveSpan(ROOT_CONTEXT, STUB_SPAN)
+  const dummyContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
 
   const fastify = require('fastify')()
 


### PR DESCRIPTION
### Summary
- Update to `@opentelemetry/api` v0.15.0. (See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-js/blob/main/CHANGELOG.md#0150))
  - The following `@opentelemetry/api` exports consumed by this plugin have been renamed:
    - `setActiveSpan` -> `setSpan`
    - `getActiveSpan` -> `getSpan`
- Update OpenTelemetry dev dependencies to v0.15.0.

### Test Plan
- Run the example App.
- Go to http://localhost:3000
- Check terminal and confirm traces.