### PR TITLE
feat: Update to @opentelemetry/api v0.17.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fastify.listen(3000, (err, address) => {
   }
 })
 ```
-##### OpenTelemetry/API Configuration
+##### OpenTelemetry API Configuration
 ```js
 // openTelemetryConfig.js
 const {
@@ -76,7 +76,7 @@ provider.register({
 })
 
 // Note: the above is just a basic example. fastify-opentelemetry is compatible with any
-// @opentelemetry/api(0.15.0) configuration.
+// @opentelemetry/api(0.17.0) configuration.
 ```
 
 
@@ -156,8 +156,9 @@ This plugin registers the following Fastify hooks:
  - `onRoute`: Added only if `wrapRoutes` is enabled.
 
  #### OpenTelemetry Compatibility
-  As of version `0.8.0` this plugin is compatible with `@opentelemetry/api@0.15.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
+  As of version `0.9.0` this plugin is compatible with `@opentelemetry/api@0.17.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
 
+  - `@opentelemetry/api@0.15.0` -> `@autotelic/fastify-opentelemetry@0.8.0`
   - `@opentelemetry/api@0.14.0` -> `@autotelic/fastify-opentelemetry@0.7.0`
   - `@opentelemetry/api@0.13.0` -> `@autotelic/fastify-opentelemetry@0.5.0`
   - `@opentelemetry/api@0.12.0` -> `@autotelic/fastify-opentelemetry@0.4.0`
@@ -165,8 +166,8 @@ This plugin registers the following Fastify hooks:
   - `@opentelemetry/api@0.9.0` -> `@autotelic/fastify-opentelemetry@0.1.1`
 
 [Fastify]: https://fastify.io
-[OpenTelemetry API]: https://open-telemetry.github.io/opentelemetry-js/index.html
-[`Context`]: https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-context-base/src/types.ts
+[OpenTelemetry API]: https://github.com/open-telemetry/opentelemetry-js-api
+[`Context`]: https://open-telemetry.github.io/opentelemetry-js/interfaces/context.html
 [`Propagation.extract`]: https://open-telemetry.github.io/opentelemetry-js/classes/propagationapi.html#extract
 [`Propagation.inject`]: https://open-telemetry.github.io/opentelemetry-js/classes/propagationapi.html#inject
 [`Span`]: https://open-telemetry.github.io/opentelemetry-js/interfaces/span.html
@@ -175,5 +176,5 @@ This plugin registers the following Fastify hooks:
 [`defaultTextMapGetter`]: https://open-telemetry.github.io/opentelemetry-js/globals.html#defaulttextmapgetter
 [`TextMapSetter`]: https://open-telemetry.github.io/opentelemetry-js/interfaces/textmapsetter.html
 [`defaultTextMapSetter`]: https://open-telemetry.github.io/opentelemetry-js/globals.html#defaulttextmapsetter
-[OpenTelemetry instrumentations]: https://github.com/open-telemetry/opentelemetry-js#plugins
+[OpenTelemetry instrumentations]: https://github.com/open-telemetry/opentelemetry-js#node-instrumentations--plugins
 [`AsyncHooksContextManager`]: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {
   getSpan,
   propagation,
   setSpan,
-  StatusCode,
+  SpanStatusCode,
   trace
 } = require('@opentelemetry/api')
 
@@ -101,10 +101,10 @@ async function openTelemetryPlugin (fastify, opts = {}) {
 
     const activeContext = getContext(request)
     const span = getSpan(activeContext)
-    const spanStatus = { code: StatusCode.OK }
+    const spanStatus = { code: SpanStatusCode.OK }
 
     if (reply.statusCode >= 400) {
-      spanStatus.code = StatusCode.ERROR
+      spanStatus.code = SpanStatusCode.ERROR
     }
 
     span.setAttributes(formatSpanAttributes.reply(reply))

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^0.15.0",
-    "@opentelemetry/core": "^0.15.0",
-    "@opentelemetry/tracing": "^0.15.0",
+    "@opentelemetry/context-async-hooks": "^0.17.0",
+    "@opentelemetry/core": "^0.17.0",
+    "@opentelemetry/tracing": "^0.17.0",
     "fastify": "^3.8.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
@@ -43,7 +43,7 @@
     "tap": "^14.11.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.15.0",
+    "@opentelemetry/api": "^0.17.0",
     "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {

--- a/test/fixtures/openTelemetryApi.js
+++ b/test/fixtures/openTelemetryApi.js
@@ -2,12 +2,13 @@ const { stub } = require('sinon')
 
 const {
   context,
-  NOOP_SPAN,
   NOOP_TRACER,
   NOOP_TRACER_PROVIDER,
   propagation,
   trace
 } = require('@opentelemetry/api')
+
+const NOOP_SPAN = NOOP_TRACER.startSpan()
 
 stub(NOOP_SPAN, 'end')
 stub(NOOP_SPAN, 'setAttributes')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,7 @@ const {
   getSpan,
   setSpan,
   ROOT_CONTEXT,
-  StatusCode
+  SpanStatusCode
 } = require('@opentelemetry/api')
 
 const {
@@ -63,7 +63,7 @@ test('should trace a successful request', async ({ is, same, teardown }) => {
   }], 'should set the default request attributes')
 
   same(STUB_SPAN.setAttributes.args[1], [{ 'reply.statusCode': 200 }], 'should set the default reply attributes')
-  same(STUB_SPAN.setStatus.args[0], [{ code: StatusCode.OK }], 'should set the span status to the correct status code')
+  same(STUB_SPAN.setStatus.args[0], [{ code: SpanStatusCode.OK }], 'should set the span status to the correct status code')
   is(STUB_SPAN.end.calledOnce, true, 'should end the span')
 })
 
@@ -98,7 +98,7 @@ test('should trace an unsuccessful request', async ({ is, same, teardown }) => {
   }], 'should set the default error attributes')
 
   same(STUB_SPAN.setAttributes.args[2], [{ 'reply.statusCode': 500 }], 'should set the default reply attributes')
-  same(STUB_SPAN.setStatus.args[0], [{ code: StatusCode.ERROR }], 'should set the span status to the correct status code')
+  same(STUB_SPAN.setStatus.args[0], [{ code: SpanStatusCode.ERROR }], 'should set the span status to the correct status code')
   is(STUB_SPAN.end.calledOnce, true, 'should end the span')
 })
 
@@ -135,7 +135,7 @@ test('should trace request using provided formatSpanAttributes merged with defau
   }], 'should set the custom request attributes')
 
   same(STUB_SPAN.setAttributes.args[1], [{ 'reply.statusCode': 200 }], 'should set the default reply attributes')
-  same(STUB_SPAN.setStatus.args[0], [{ code: StatusCode.OK }], 'should set the span status to the correct status code')
+  same(STUB_SPAN.setStatus.args[0], [{ code: SpanStatusCode.OK }], 'should set the span status to the correct status code')
   is(STUB_SPAN.end.calledOnce, true, 'should end the span')
 })
 


### PR DESCRIPTION
### Summary
- Update to `@opentelemetry/api` v0.17.0. (See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-js/blob/main/CHANGELOG.md#0170))
  - The following `@opentelemetry/api` exports consumed by this plugin have been renamed:
    - `StatusCode` -> `SpanStatusCode`
- Update OpenTelemetry dev dependencies to v0.17.0.
- Update testing fixtures -> `NOOP_SPAN` is no longer exported from `@opentelemetry/api`.

### Test Plan
- Run the example App.
- Go to http://localhost:3000
- Check terminal and confirm traces.