### PR TITLE
feat: Update to @opentelemetry/api v0.18.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ provider.register({
 })
 
 // Note: the above is just a basic example. fastify-opentelemetry is compatible with any
-// @opentelemetry/api(0.17.0) configuration.
+// @opentelemetry/api(0.18.0) configuration.
 ```
 
 
@@ -156,8 +156,9 @@ This plugin registers the following Fastify hooks:
  - `onRoute`: Added only if `wrapRoutes` is enabled.
 
  #### OpenTelemetry Compatibility
-  As of version `0.9.0` this plugin is compatible with `@opentelemetry/api@0.17.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
+  As of version `0.10.0` this plugin is compatible with `@opentelemetry/api@0.18.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
 
+  - `@opentelemetry/api@0.17.0` -> `@autotelic/fastify-opentelemetry@0.9.0`
   - `@opentelemetry/api@0.15.0` -> `@autotelic/fastify-opentelemetry@0.8.0`
   - `@opentelemetry/api@0.14.0` -> `@autotelic/fastify-opentelemetry@0.7.0`
   - `@opentelemetry/api@0.13.0` -> `@autotelic/fastify-opentelemetry@0.5.0`

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/core": "^0.17.0",
-    "@opentelemetry/tracing": "^0.17.0",
+    "@opentelemetry/context-async-hooks": "^0.18.0",
+    "@opentelemetry/core": "^0.18.0",
+    "@opentelemetry/tracing": "^0.18.0",
     "fastify": "^3.8.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
@@ -43,7 +43,7 @@
     "tap": "^14.11.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.1",
     "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
### Summary
- Update to `@opentelemetry/api` v0.18.0. (See [CHANGELOG](https://github.com/open-telemetry/opentelemetry-js/blob/main/CHANGELOG.md#0180))
 
### Test Plan
- Run the example App.
- Go to http://localhost:3000
- Check terminal and confirm traces.