### PR TITLE
fix: remove public dependencies due to potential conflicts in opentelemetry-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,18 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^0.18.1",
     "@opentelemetry/context-async-hooks": "^0.18.0",
     "@opentelemetry/core": "^0.18.0",
     "@opentelemetry/tracing": "^0.18.0",
     "fastify": "^3.8.0",
-    "fastify-plugin": "^3.0.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
     "standard": "^16.0.3",
     "tap": "^14.11.0"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^0.18.0",
+    "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/package.json
+++ b/package.json
@@ -33,18 +33,16 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^0.18.1",
     "@opentelemetry/context-async-hooks": "^0.18.0",
     "@opentelemetry/core": "^0.18.0",
     "@opentelemetry/tracing": "^0.18.0",
     "fastify": "^3.8.0",
+    "fastify-plugin": "^3.0.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
     "standard": "^16.0.3",
     "tap": "^14.11.0"
-  },
-  "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
-    "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
Potential solution for resolving the situation where multiple "opentelemetry-api" modules are loaded.
Move all "runtime" dependencies to "devDependencies".

Alternative would be to use peer dependencies, as discussed on #22 