### PR TITLE
fix: handle when running within a nested span

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,13 @@ async function openTelemetryPlugin (fastify, opts = {}) {
   async function onRequest (request, reply) {
     if (ignoreRoutes.includes(request.url)) return
 
-    const activeContext = propagation.extract(context.active(), request.headers)
+    let activeContext = context.active();
+
+    // if not running within a local span then extract the context from the headers carrier
+    if (!getSpan(activeContext)) {
+      activeContext = propagation.extract(activeContext, request.headers)
+    }
+
     const span = tracer.startSpan(
       formatSpanName(serviceName, request.raw),
       {},

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
   async function onRequest (request, reply) {
     if (ignoreRoutes.includes(request.url)) return
 
-    let activeContext = context.active();
+    let activeContext = context.active()
 
     // if not running within a local span then extract the context from the headers carrier
     if (!getSpan(activeContext)) {


### PR DESCRIPTION
If running within another instrumentation library, such as instrumentation-https, and the b3 headers are provided, the fastify-opentelemetry span is created under the wrong parent, this change will check to see if an existing span for a given context at creation time, and if so will use that instead of regenerating.


Note, this PR is primarily used to indicate the actual fix to #25 , but I can't figure out yet how to actually test it (so guidance would be appreciated)!
