### PR TITLE
feat: Update to @opentelemetry/api v1.0.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ provider.register({
 })
 
 // Note: the above is just a basic example. fastify-opentelemetry is compatible with any
-// @opentelemetry/api(0.18.0) configuration.
+// @opentelemetry/api configuration.
 ```
 
 
@@ -155,16 +155,24 @@ This plugin registers the following Fastify hooks:
 
  - `onRoute`: Added only if `wrapRoutes` is enabled.
 
- #### OpenTelemetry Compatibility
-  As of version `0.10.0` this plugin is compatible with `@opentelemetry/api@0.18.0`. Older versions of OpenTelemetry will require previous releases of fastify-opentelemetry.
+#### OpenTelemetry Compatibility
 
-  - `@opentelemetry/api@0.17.0` -> `@autotelic/fastify-opentelemetry@0.9.0`
-  - `@opentelemetry/api@0.15.0` -> `@autotelic/fastify-opentelemetry@0.8.0`
-  - `@opentelemetry/api@0.14.0` -> `@autotelic/fastify-opentelemetry@0.7.0`
-  - `@opentelemetry/api@0.13.0` -> `@autotelic/fastify-opentelemetry@0.5.0`
-  - `@opentelemetry/api@0.12.0` -> `@autotelic/fastify-opentelemetry@0.4.0`
-  - `@opentelemetry/api@0.10.0` -> `@autotelic/fastify-opentelemetry@0.2.4`
-  - `@opentelemetry/api@0.9.0` -> `@autotelic/fastify-opentelemetry@0.1.1`
+As the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-js-api#version-compatibility) uses a
+variable on the `global` object to store the global API, care needs to be taken to ensure all modules are compatible.
+
+Each version of the OpenTelemetry API will require a specific release of fastify-opentelemetry.
+
+| OpenTelemetry API Version       | Minimum Fastify OpenTelemetry Version      |
+| ------------------------------- | ------------------------------------------ |
+| `@opentelemetry/api@1.0.0-rc.0` |  `@autotelic/fastify-opentelemetry@0.12.0` |
+| `@opentelemetry/api@0.18.0`     |  `@autotelic/fastify-opentelemetry@0.10.0` |
+| `@opentelemetry/api@0.17.0`     |  `@autotelic/fastify-opentelemetry@0.9.0`  |
+| `@opentelemetry/api@0.15.0`     |  `@autotelic/fastify-opentelemetry@0.8.0`  |
+| `@opentelemetry/api@0.14.0`     |  `@autotelic/fastify-opentelemetry@0.7.0`  |
+| `@opentelemetry/api@0.13.0`     |  `@autotelic/fastify-opentelemetry@0.5.0`  |
+| `@opentelemetry/api@0.12.0`     |  `@autotelic/fastify-opentelemetry@0.4.0`  |
+| `@opentelemetry/api@0.10.0`     |  `@autotelic/fastify-opentelemetry@0.2.4`  |
+| `@opentelemetry/api@0.9.0`      |  `@autotelic/fastify-opentelemetry@0.1.1`  |
 
 [Fastify]: https://fastify.io
 [OpenTelemetry API]: https://github.com/open-telemetry/opentelemetry-js-api

--- a/package.json
+++ b/package.json
@@ -36,9 +36,10 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "^0.18.0",
-    "@opentelemetry/core": "^0.18.0",
-    "@opentelemetry/tracing": "^0.18.0",
+    "@opentelemetry/api": "^1.0.0-rc.0",
+    "@opentelemetry/context-async-hooks": "^0.19.0",
+    "@opentelemetry/core": "^0.19.0",
+    "@opentelemetry/tracing": "^0.19.0",
     "@types/node": "^14.14.36",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
@@ -46,14 +47,18 @@
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-standard": "^5.0.0",
     "fastify": "^3.8.0",
+    "fastify-plugin": "^3.0.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
     "standard": "^16.0.3",
     "tap": "^14.11.0",
     "tsd": "^0.14.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.0",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eslint-config-standard": "^16.0.2",
     "eslint-plugin-standard": "^5.0.0",
     "fastify": "^3.8.0",
-    "fastify-plugin": "^3.0.0",
     "lint-staged": "^10.5.2",
     "sinon": "^9.2.1",
     "standard": "^16.0.3",
@@ -58,7 +57,6 @@
     "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "fastify-plugin": "^3.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
Required upgrade in order to remain compatible with the latest opentelemetry releases.

Update to 1.0.0-rc.0 of the API and 0.19 of the other libraries.

Also switched the API dependency to be a peerDependency to remain consistent with the changes done in the opentelemtry APIs under https://github.com/open-telemetry/opentelemetry-js/pull/2074 