### PR TITLE
feat: update to opentelemetry/api v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Each version of the OpenTelemetry API will require a specific release of fastify
 
 | OpenTelemetry API Version       | Minimum Fastify OpenTelemetry Version      |
 | ------------------------------- | ------------------------------------------ |
+| `@opentelemetry/api@0.20.0`     |  `@autotelic/fastify-opentelemetry@0.13.0` |
 | `@opentelemetry/api@1.0.0-rc.0` |  `@autotelic/fastify-opentelemetry@0.12.0` |
 | `@opentelemetry/api@0.18.0`     |  `@autotelic/fastify-opentelemetry@0.10.0` |
 | `@opentelemetry/api@0.17.0`     |  `@autotelic/fastify-opentelemetry@0.9.0`  |

--- a/example/opentelemetry.js
+++ b/example/opentelemetry.js
@@ -1,4 +1,4 @@
-const { HttpTraceContext } = require('@opentelemetry/core')
+const { HttpTraceContextPropagator } = require('@opentelemetry/core')
 const { AsyncHooksContextManager } = require('@opentelemetry/context-async-hooks')
 const {
   BasicTracerProvider,
@@ -14,5 +14,5 @@ provider.addSpanProcessor(
 
 provider.register({
   contextManager: (new AsyncHooksContextManager()).enable(),
-  propagator: new HttpTraceContext()
+  propagator: new HttpTraceContextPropagator()
 })

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
-    "@opentelemetry/context-async-hooks": "^0.19.0",
-    "@opentelemetry/core": "^0.19.0",
-    "@opentelemetry/tracing": "^0.19.0",
+    "@opentelemetry/api": "^0.20.0",
+    "@opentelemetry/context-async-hooks": "^0.20.0",
+    "@opentelemetry/core": "^0.20.0",
+    "@opentelemetry/tracing": "^0.20.0",
     "@types/node": "^14.14.36",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
@@ -54,7 +54,7 @@
     "tsd": "^0.14.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0"
+    "@opentelemetry/api": "^0.20.0"
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,10 +4,9 @@ const {
   context,
   defaultTextMapGetter,
   defaultTextMapSetter,
-  getSpan,
-  setSpan,
   ROOT_CONTEXT,
-  SpanStatusCode
+  SpanStatusCode,
+  trace
 } = require('@opentelemetry/api')
 
 const {
@@ -166,7 +165,7 @@ test('should be able to access context, activeSpan, extract, inject, and tracer 
     const newSpan = tracer.startSpan('newSpan', {}, extract(request.headers))
 
     activeSpan.setAttribute('foo', 'bar')
-    getSpan(context).setAttribute('bar', 'foo')
+    trace.getSpan(context).setAttribute('bar', 'foo')
 
     inject(replyHeaders)
     reply.headers(replyHeaders)
@@ -183,7 +182,7 @@ test('should be able to access context, activeSpan, extract, inject, and tracer 
 
   await fastify.inject(injectArgs)
 
-  const expectedContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
+  const expectedContext = trace.setSpan(ROOT_CONTEXT, STUB_SPAN)
 
   is(STUB_SPAN.setAttribute.calledWith('foo', 'bar'), true)
   is(STUB_SPAN.setAttribute.calledWith('bar', 'foo'), true)
@@ -194,7 +193,7 @@ test('should be able to access context, activeSpan, extract, inject, and tracer 
 })
 
 test('should wrap all routes when wrapRoutes is true', async ({ is, same, teardown }) => {
-  const dummyContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
+  const dummyContext = trace.setSpan(ROOT_CONTEXT, STUB_SPAN)
 
   const fastify = require('fastify')()
 
@@ -236,7 +235,7 @@ test('should wrap all routes when wrapRoutes is true', async ({ is, same, teardo
 })
 
 test('should only wrap routes provided in wrapRoutes array', async ({ same, is, teardown }) => {
-  const dummyContext = setSpan(ROOT_CONTEXT, STUB_SPAN)
+  const dummyContext = trace.setSpan(ROOT_CONTEXT, STUB_SPAN)
 
   const fastify = require('fastify')()
 


### PR DESCRIPTION
Updating to latest opentelemetry versions, note the change back from an "rc" version to a dot version (see https://github.com/open-telemetry/opentelemetry-js-api/issues/74 for the history).  Hopefully the API will go 1.X final in a few weeks.

API changes including "span.context" renamed to "span.spanContext" (which does not impact this library), and the getSpan/setSpan moved to the trace object, which does impact this library.

I've added a version compatibility note to the README, but please check correct version reference when creating a release.