### PR TITLE
feat: update to opentelemetry-api 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Each version of the OpenTelemetry API will require a specific release of fastify
 
 | OpenTelemetry API Version       | Minimum Fastify OpenTelemetry Version      |
 | ------------------------------- | ------------------------------------------ |
+| `@opentelemetry/api@1.0.0`      |  `@autotelic/fastify-opentelemetry@0.14.0` |
 | `@opentelemetry/api@0.20.0`     |  `@autotelic/fastify-opentelemetry@0.13.0` |
 | `@opentelemetry/api@1.0.0-rc.0` |  `@autotelic/fastify-opentelemetry@0.12.0` |
 | `@opentelemetry/api@0.18.0`     |  `@autotelic/fastify-opentelemetry@0.10.0` |

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "node": ">=10.16.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^0.20.0",
-    "@opentelemetry/instrumentation": "^0.20.0",
-    "@opentelemetry/instrumentation-http": "^0.20.0",
-    "@opentelemetry/node": "^0.20.0",
-    "@opentelemetry/tracing": "^0.20.0",
+    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/instrumentation": "^0.22.0",
+    "@opentelemetry/instrumentation-http": "^0.22.0",
+    "@opentelemetry/node": "^0.22.0",
+    "@opentelemetry/tracing": "^0.22.0",
     "@types/node": "^14.14.36",
     "@typescript-eslint/eslint-plugin": "^4.20.0",
     "@typescript-eslint/parser": "^4.20.0",
@@ -55,7 +55,7 @@
     "tsd": "^0.14.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^0.20.0"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0"

--- a/test/fixtures/openTelemetryApi.js
+++ b/test/fixtures/openTelemetryApi.js
@@ -2,33 +2,32 @@ const { stub } = require('sinon')
 
 const {
   context,
-  NOOP_TRACER,
-  NOOP_TRACER_PROVIDER,
   propagation,
   trace
 } = require('@opentelemetry/api')
 
-const NOOP_SPAN = NOOP_TRACER.startSpan()
+const { name: moduleName, version: moduleVersion } = require('../../package.json')
 
-stub(NOOP_SPAN, 'end')
-stub(NOOP_SPAN, 'setAttributes')
-stub(NOOP_SPAN, 'setAttribute')
-stub(NOOP_SPAN, 'setStatus')
+const stubTracer = trace.getTracer(moduleName, moduleVersion)
+const stubSpan = stubTracer.startSpan('stubSpan')
 
-stub(NOOP_TRACER, 'startSpan').returns(NOOP_SPAN)
+stub(stubSpan, 'end')
+stub(stubSpan, 'setAttributes')
+stub(stubSpan, 'setAttribute')
+stub(stubSpan, 'setStatus')
 
-stub(trace, 'getTracer').returns(NOOP_TRACER)
+stub(stubTracer, 'startSpan').returns(stubSpan)
+
+stub(trace, 'getTracer').returns(stubTracer)
 
 stub(propagation, 'extract').callThrough()
 stub(propagation, 'inject').callThrough()
 
 stub(context, 'with').callThrough()
 
-trace.setGlobalTracerProvider(NOOP_TRACER_PROVIDER)
-
 module.exports = {
-  STUB_SPAN: NOOP_SPAN,
-  STUB_TRACER: NOOP_TRACER,
+  STUB_SPAN: stubSpan,
+  STUB_TRACER: stubTracer,
   STUB_TRACE_API: trace,
   STUB_PROPAGATION_API: propagation,
   STUB_CONTEXT_API: context


### PR DESCRIPTION
Update to the 1.0.0 opentelemetry-api release.

Note, as per the [upgrade-guidelines](https://github.com/open-telemetry/opentelemetry-js-api#upgrade-guidelines), NOOP_* are no longer exported, but as we were just stubbing out the functions I have simply replaced with equivalents using the direct APIs.  

The alternative here (bit more work) would be to switch around the test setup and utilise the [InMemorySpanExporter](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-tracing/src/export/InMemorySpanExporter.ts) to verify spans exported at the end instead (but slightly beyond scope of this change).