### PR TITLE
feat: Allow ignoreRoutes to be a function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,20 @@ The plugin accepts the the following configuration properties:
       }
       ```
 
-  - **`wrapRoutes` : `boolean | String[]`** - When `true`, all route handlers will be executed with an active context equal to `request.openTelemetry().context`. Also accepts an array containing all route paths that should be wrapped. Optional - disabled by default.
+  - **`wrapRoutes` : `boolean | string[]`** - When `true`, all route handlers will be executed with an active context equal to `request.openTelemetry().context`. Also accepts an array containing all route paths that should be wrapped. Optional - disabled by default.
     - Route paths must have a leading `/` and no trailing `/` (eg. `'/my/exact/route/path'`).
     - Wrapping a route allows for any span created within the scope of the route handler to automatically become children of the current request's `activeSpan`. This includes spans created by automated [OpenTelemetry instrumentations].
     - A global context manager (eg. [`AsyncHooksContextManager`]) is required to provide an active context to the route handler.
 
-  - **`ignoreRoutes` : `String[]`** - All [hooks](#hooks) added by this plugin will ignore the route paths contained in this array (ie. no automated tracing for that route). Takes precedence over `wrapRoutes`.
-    - Route paths must follow the same format as `wrapRoutes`.
+  - **`ignoreRoutes` : `string[] | (path: string, method: string) => boolean`** - Configure the [hooks](#hooks) added by this plugin to ignore certain route paths (ie. no automated tracing for that route). Takes precedence over `wrapRoutes`.
+    - Can be an array of Route paths (following the same format as `wrapRoutes`).
+    - Can be a function that receives a route's path and method, and returns a boolean (return `true` to ignore). For example, to disable tracing on `OPTIONS` routes:
+      ```js
+      fastify.register(openTelemetryPlugin, {
+        serviceName: 'my-service',
+        ignoreRoutes: (path, method) => method === 'OPTIONS'
+      })
+      ```
     - The ignored routes will still have access to `request.openTelemetry`, but `activeSpan` will be `undefined`.
 
 #### Request Decorator

--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -31,7 +31,7 @@ export interface OpenTelemetryPluginOptions {
     readonly error?: (error: Error) => SpanAttributes,
   },
   readonly wrapRoutes?: boolean | string[],
-  readonly ignoreRoutes?: string[],
+  readonly ignoreRoutes?: string[] | ((path: string, method: string) => boolean),
 }
 
 declare const fastifyOpenTelemetry: FastifyPluginCallback<OpenTelemetryPluginOptions>

--- a/test/types/fastify-opentelemetry.test-d.ts
+++ b/test/types/fastify-opentelemetry.test-d.ts
@@ -22,7 +22,7 @@ expectType(<OpenTelemetryPluginOptions>({
   formatSpanAttributes: {},
   ignoreRoutes: ['/a', '/b'],
   serviceName: 'service-name',
-  wrapRoutes: true
+  wrapRoutes: ['/c']
 }))
 
 // should be able to construct a full options object
@@ -45,7 +45,7 @@ expectType(<OpenTelemetryPluginOptions>({
       }
     }
   },
-  ignoreRoutes: [],
+  ignoreRoutes: (path: string, method: string) => method === 'OPTIONS',
   formatSpanName: (serviceName: string, raw: FastifyRequest['raw']) => `${raw.method} ${serviceName} constant-part`,
   serviceName: 'service-name',
   wrapRoutes: true


### PR DESCRIPTION
### Summary
 - Updates the `ignoreRoutes` option to accept an array or a function (previously only accepted an array)
 - An `ignoreRoutes` function is passed a route's path and method, and expected to return a boolean 
 - Resolves #38 