### PR TITLE
fix!: use low-cardinality span name and remove serviceName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ require('./openTelemetryConfig')
 const openTelemetryPlugin = require('@autotelic/fastify-opentelemetry')
 const fastify = require('fastify')()
 
-fastify.register(openTelemetryPlugin, { serviceName: 'my-service', wrapRoutes: true })
+fastify.register(openTelemetryPlugin, { wrapRoutes: true })
 
 fastify.get('/', async function (request, reply) {
   const {
@@ -82,11 +82,9 @@ npm run dev
 This plugin leaves all tracer configuration to the [OpenTelemetry API]. The tracer and propagation method are pulled in from the global tracer provider and global propagator, respectively. This allows the config for the plugin itself to be minimal.
 
 The plugin accepts the the following configuration properties:
-  - **`serviceName`: `string`** - Used for naming the tracer and spans (not required, but recommended).
-
   - **`exposeApi` : `boolean`** - Used to prevent the plugin from decorating the request. By default the request will be decorated (i.e. defaults to `true`).
 
-  - **`formatSpanName` : `(serviceName, FastifyRequest.raw) => string`** - Custom formatter for the span name. The default format is ``` `${serviceName} - ${raw.method} - ${raw.url}` ```.
+  - **`formatSpanName` : `(FastifyRequest) => string`** - Custom formatter for the span name. The default format is ``` `${req.method} {req.routerPath}` ```.
 
   - **`formatSpanAttributes` : `object`** - Contains formatting functions for span attributes. *Properties*:
     - **`request`: `(FastifyRequest) => object`** - On request, the returned object will be added to the current span's attributes. The default request attributes are:
@@ -116,7 +114,6 @@ The plugin accepts the the following configuration properties:
     - Can be a function that receives a route's path and method, and returns a boolean (return `true` to ignore). For example, to disable tracing on `OPTIONS` routes:
       ```js
       fastify.register(openTelemetryPlugin, {
-        serviceName: 'my-service',
         ignoreRoutes: (path, method) => method === 'OPTIONS'
       })
       ```

--- a/example/index.js
+++ b/example/index.js
@@ -5,21 +5,49 @@ const fastify = require('fastify')
 const fetch = require('node-fetch')
 const fastifyOpentelemetry = require('..')
 
+const boredApi = 'https://www.boredapi.com'
 const app = fastify()
 
 app.register(fastifyOpentelemetry, { serviceName: 'basic-example', wrapRoutes: true })
 
-app.get('/', async function routeHandler (request, reply) {
+app.get('/', async function routeHandler(request, reply) {
   const {
     tracer
   } = request.openTelemetry()
   let childSpan
   try {
     // @opentelemetry/instrumentation-http will automatically trace incoming and out going http/https requests.
-    const activityRes = await fetch('https://www.boredapi.com/api/activity')
+    const activityRes = await fetch(`${boredApi}/api/activity`)
     // Spans started in a wrapped route will automatically be children of the activeSpan.
     childSpan = tracer.startSpan('preparing content')
     const { activity } = await activityRes.json()
+    reply.type('text/html')
+    return `<h1>Bored?</h1><h3>Have you tried to ${activity.toLowerCase()}</h3>`
+  } catch (error) {
+    // fastify-opentelemetry automatically adds error data to the parent spans attributes.
+    return error
+  } finally {
+    // Always be sure to end child spans.
+    if (childSpan) childSpan.end()
+  }
+})
+
+app.get('/:type', async function routeHandler(request, reply) {
+  const { tracer } = request.openTelemetry()
+  let childSpan
+  try {
+    // @opentelemetry/instrumentation-http will automatically trace incoming and out going http/https requests.
+    const activityRes = await fetch(
+      `${boredApi}/api/activity?type=${request.params.type}`
+    )
+    // Spans started in a wrapped route will automatically be children of the activeSpan.
+    childSpan = tracer.startSpan(`preparing content of ${request.params.type}`)
+    const { activity, error } = await activityRes.json()
+
+    if (error) {
+      throw error
+    }
+
     reply.type('text/html')
     return `<h1>Bored?</h1><h3>Have you tried to ${activity.toLowerCase()}</h3>`
   } catch (error) {

--- a/example/index.js
+++ b/example/index.js
@@ -10,7 +10,7 @@ const app = fastify()
 
 app.register(fastifyOpentelemetry, { serviceName: 'basic-example', wrapRoutes: true })
 
-app.get('/', async function routeHandler(request, reply) {
+app.get('/', async function routeHandler (request, reply) {
   const {
     tracer
   } = request.openTelemetry()
@@ -32,7 +32,7 @@ app.get('/', async function routeHandler(request, reply) {
   }
 })
 
-app.get('/:type', async function routeHandler(request, reply) {
+app.get('/:type', async function routeHandler (request, reply) {
   const { tracer } = request.openTelemetry()
   let childSpan
   try {

--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -22,9 +22,8 @@ declare module 'fastify' {
  * Options for the OpenTelemetry plugin.
  */
 export interface OpenTelemetryPluginOptions {
-  readonly serviceName?: string,
   readonly exposeApi?: boolean,
-  readonly formatSpanName?: (serviceName: string, raw: FastifyRequest['raw']) => string,
+  readonly formatSpanName?: (request: FastifyRequest) => string,
   readonly formatSpanAttributes?: {
     readonly request?: (request: FastifyRequest) => SpanAttributes,
     readonly reply?: (reply: FastifyReply) => SpanAttributes,

--- a/index.js
+++ b/index.js
@@ -10,8 +10,12 @@ const {
 
 const { name: moduleName, version: moduleVersion } = require('./package.json')
 
-function defaultFormatSpanName (serviceName, rawReq) {
-  return `${serviceName} - ${rawReq.method} - ${rawReq.url}`
+function defaultFormatSpanName (serviceName, request) {
+  const parts = [serviceName, request.method]
+  if(request.routerPath) {
+    parts.push(request.routerPath)
+  }
+  return parts.join(" ")
 }
 
 const defaultFormatSpanAttributes = {
@@ -96,7 +100,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
     }
 
     const span = tracer.startSpan(
-      formatSpanName(serviceName, request.raw),
+      formatSpanName(serviceName, request),
       {},
       activeContext
     )

--- a/index.js
+++ b/index.js
@@ -11,11 +11,8 @@ const {
 const { name: moduleName, version: moduleVersion } = require('./package.json')
 
 function defaultFormatSpanName (request) {
-  const parts = [request.method]
-  if(request.routerPath) {
-    parts.push(request.routerPath)
-  }
-  return parts.join(" ")
+  const { method, routerPath } = request
+  return routerPath ? `${method} ${routerPath}` : method
 }
 
 const defaultFormatSpanAttributes = {
@@ -41,7 +38,6 @@ const defaultFormatSpanAttributes = {
 
 async function openTelemetryPlugin (fastify, opts = {}) {
   const {
-    serviceName,
     wrapRoutes,
     exposeApi = true,
     formatSpanName = defaultFormatSpanName,

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const {
 
 const { name: moduleName, version: moduleVersion } = require('./package.json')
 
-function defaultFormatSpanName (serviceName, request) {
-  const parts = [serviceName, request.method]
+function defaultFormatSpanName (request) {
+  const parts = [request.method]
   if(request.routerPath) {
     parts.push(request.routerPath)
   }
@@ -100,7 +100,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
     }
 
     const span = tracer.startSpan(
-      formatSpanName(serviceName, request),
+      formatSpanName(request),
       {},
       activeContext
     )

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -395,7 +395,7 @@ test('should use router path in span name', async ({ is, same, teardown }) => {
 
   const activeContext = stub(context, 'active').returns({
     getValue: () => STUB_SPAN,
-    setValue: () => null,
+    setValue: () => null
   })
 
   teardown(() => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -409,12 +409,12 @@ test('should use router path in span name', async ({ is, same, teardown }) => {
 
   same(
     STUB_TRACER.startSpan.args[0][0],
-    'service1 GET /test',
+    'GET /test',
     'should contain router path'
   )
   same(
     STUB_TRACER.startSpan.args[1][0],
-    'service1 GET',
+    'GET',
     'should not contain router path when no matching routes found'
   )
 })

--- a/test/types/fastify-opentelemetry.test-d.ts
+++ b/test/types/fastify-opentelemetry.test-d.ts
@@ -21,7 +21,6 @@ expectType(<OpenTelemetryPluginOptions>({
   exposeApi: true,
   formatSpanAttributes: {},
   ignoreRoutes: ['/a', '/b'],
-  serviceName: 'service-name',
   wrapRoutes: ['/c']
 }))
 
@@ -46,7 +45,6 @@ expectType(<OpenTelemetryPluginOptions>({
     }
   },
   ignoreRoutes: (path: string, method: string) => method === 'OPTIONS',
-  formatSpanName: (serviceName: string, raw: FastifyRequest['raw']) => `${raw.method} ${serviceName} constant-part`,
-  serviceName: 'service-name',
+  formatSpanName: (request: FastifyRequest) => `${request.method} constant-part`,
   wrapRoutes: true
 }))


### PR DESCRIPTION
* Use low-cardinality span name. Use `routerPath` instead of raw URL
* removed service name from the option because span name does not need to contain service name, service name should be set either on the provider or exporter.
    
  ```
  import { ResourceAttributes } from "@opentelemetry/semantic-conventions";
  import { SimpleSpanProcessor } from "@opentelemetry/tracing";
  
  .....
  const traceProvider = new NodeTracerProvider({
    resource: new Resource({
      [ResourceAttributes.SERVICE_NAME]: "myservice",
    }),
  });
  ```
    
**BREAKING CHANGE!**: service name removed from the usage and formatSpanName

Closes #40 