### PR TITLE
feat: Decorate openTelemetry with traceId

### DIFF
--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -8,6 +8,7 @@ export interface OpenTelemetryReqInstance {
   readonly activeSpan: Span | undefined,
   readonly context: Context,
   readonly tracer: Tracer,
+  readonly traceId: string | undefined,
   readonly inject: <Carrier> (carrier: Carrier, setter?: TextMapSetter) => void,
   readonly extract: <Carrier> (carrier: Carrier, getter?: TextMapGetter) => Context,
 }

--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ async function openTelemetryPlugin (fastify, opts = {}) {
       get tracer () {
         return tracer
       },
+      get traceId () {
+        return trace.getSpan(getContext(request))?.spanContext().traceId
+      },
       inject (carrier, setter = defaultTextMapSetter) {
         return propagation.inject(getContext(request), carrier, setter)
       },


### PR DESCRIPTION
Fixes https://github.com/autotelic/fastify-opentelemetry/issues/42

Also RFC, should adding this behind an option be something you'd want? (I personally use this)

```ts
fastify.addHook('onRequest', async (request, reply) => {
    // ...
    const traceId = request.openTelemetry().traceId;

    request.log = request.log.child({traceId});
    reply.log = reply.log.child({traceId});
});
```
that way my logs all contain traceId's if there is one available