### PR TITLE
fix example of openTelemetryConfig.js in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fastify.listen(3000, (err, address) => {
 ```js
 // openTelemetryConfig.js
 const {
-  BatchSpanProcessor
+  BatchSpanProcessor,
   ConsoleSpanExporter,
 } = require('@opentelemetry/tracing')
 const { NodeTracerProvider } = require('@opentelemetry/node')


### PR DESCRIPTION
The sample for openTelemetryConfig.js is missing a `,`.