### PR TITLE
chore(fastify): upgrade fastify to 4.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,10 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org/'
+          node-version: '14.x'
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
@@ -21,12 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-        registry-url: https://registry.npmjs.org/
-    - run: npm publish --access public
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,10 +4,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '14.x'
       - run: npm install
       - run: npm run validate

--- a/index.js
+++ b/index.js
@@ -155,6 +155,6 @@ async function openTelemetryPlugin (fastify, opts = {}) {
 }
 
 module.exports = fp(openTelemetryPlugin, {
-  fastify: '3.x',
+  fastify: '4.x',
   name: 'fastify-opentelemetry'
 })

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/autotelic/fastify-opentelemetry#readme",
   "engines": {
-    "node": ">=10.16.0"
+    "node": ">=14"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^4.20.0",
     "eslint": "^7.13.0",
     "eslint-config-standard": "^16.0.2",
-    "fastify": "^3.8.0",
+    "fastify": "^4.0.0",
     "lint-staged": "^10.5.2",
     "node-fetch": "^2.6.1",
     "sinon": "^9.2.1",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -366,11 +366,6 @@ test('should not extract context headers, if an active context exists locally.',
 })
 
 test('should preserve this binding in handler using wrapRoutes', async ({ is, same, teardown }) => {
-  teardown(() => {
-    resetHistory()
-    fastify.close()
-  })
-
   let actual
   async function handleRequest (request, reply) {
     if (!this) {
@@ -388,6 +383,11 @@ test('should preserve this binding in handler using wrapRoutes', async ({ is, sa
   const reply = await fastify.inject(injectArgs)
   is(reply.statusCode, 200)
   is(fastify, actual)
+
+  teardown(() => {
+    resetHistory()
+    fastify.close()
+  })
 })
 
 test('should use router path in span name', async ({ is, same, teardown }) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -197,7 +197,7 @@ test('should wrap all routes when wrapRoutes is true', async ({ is, same, teardo
 
   const fastify = require('fastify')()
 
-  fastify.register(openTelemetryPlugin, { serviceName: 'test', wrapRoutes: true })
+  await fastify.register(openTelemetryPlugin, { serviceName: 'test', wrapRoutes: true })
 
   async function testHandlerOne (request, reply) {
     request.openTelemetry()
@@ -239,7 +239,7 @@ test('should only wrap routes provided in wrapRoutes array', async ({ same, is, 
 
   const fastify = require('fastify')()
 
-  fastify.register(openTelemetryPlugin, { serviceName: 'test', wrapRoutes: ['/testTwo'] })
+  await fastify.register(openTelemetryPlugin, { serviceName: 'test', wrapRoutes: ['/testTwo'] })
 
   const testHandlerOne = async () => 'one'
   const testHandlerTwo = async () => 'two'


### PR DESCRIPTION
Hello!

Fastify just released their version 4, so here's the update in this package.

I also upgraded `engines.node` to v14 (in Github Actions as well) as I think fastify started to use [Optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining), introduced in node 14.

3 tests are failing with wrapRoutes, so I'm investigating them at the moment