### PR TITLE
docs: Update readme to await fastify register call

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,29 +17,31 @@ require('./openTelemetryConfig')
 const openTelemetryPlugin = require('@autotelic/fastify-opentelemetry')
 const fastify = require('fastify')()
 
-fastify.register(openTelemetryPlugin, { wrapRoutes: true })
+(async () => {
+  await fastify.register(openTelemetryPlugin, { wrapRoutes: true })
 
-fastify.get('/', async function (request, reply) {
-  const {
-    activeSpan,
-    tracer,
-    // context,
-    // extract,
-    // inject,
-  } = request.openTelemetry()
-  // Spans started in a wrapped route will automatically be children of the activeSpan.
-  const childSpan = tracer.startSpan(`${activeSpan.name} - child process`)
-  // doSomeWork()
-  childSpan.end()
-  return 'OK'
-})
+  fastify.get('/', async function (request, reply) {
+    const {
+      activeSpan,
+      tracer,
+      // context,
+      // extract,
+      // inject,
+    } = request.openTelemetry()
+    // Spans started in a wrapped route will automatically be children of the activeSpan.
+    const childSpan = tracer.startSpan(`${activeSpan.name} - child process`)
+    // doSomeWork()
+    childSpan.end()
+    return 'OK'
+  })
 
-fastify.listen(3000, (err, address) => {
-  if (err) {
-    fastify.log.error(err)
-    process.exit(1)
-  }
-})
+  fastify.listen(3000, (err, address) => {
+    if (err) {
+      fastify.log.error(err)
+      process.exit(1)
+    }
+  })
+})()
 ```
 
 ##### OpenTelemetry API Configuration


### PR DESCRIPTION
**tl/dr**: Since fastify v4, `fastify.register` must be awaited when registering the `onRoute` hook, which is necessary when using `wrapRoutes: true`
________

We have a fastify-based web service which uses opentelemetry for tracing (custom traces, db, etc.). To instrument fastify, we use `fastify-opentelemetry`, which so far worked perfectly.

Since upgrading to fastify v4, we have noticed that the resulting spans from a single request are not connected anymore. Usually, with `{ wrapRoutes: true }`, we would see a trace like this: `fastify (GET route/) => manually created span => some DB call`. Now, the fastify spans are transmitted on their own, as are the other spans (though in the example above there would still be the connected trace `manually created span => some DB call`); the spans created inside a route handler do not have the correct parent id set.

It turns out, this it due to a [breaking change in fastify](https://www.fastify.io/docs/latest/Guides/Migration-Guide-V4/#synchronous-route-definitions). It's necessary to `await` the `fastify.register` call which registers `fastify-opentelemetry` as a plugin.

Maybe the IIFE is not the best approach here, but to me it looks like the simplest at the moment. Let me know if there is a better way 😃 Also, it appears to be the case that everything except the wrapRoutes-Feature works great, even without awaiting the register call.