### PR TITLE
test: Fix missing line coverage when using Node v14

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,11 +3,13 @@ on: [push, pull_request, workflow_call]
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['14', '16']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org/'
       - run: npm install
       - run: npm run validate

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "^2.6.1",
     "sinon": "^9.2.1",
     "standard": "^16.0.3",
-    "tap": "^14.11.0",
+    "tap": "^16.3.0",
     "tsd": "^0.14.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Summary
 - For some reason test coverage started dipping under 100%, but only on Node v14 and not v16
   - Currently: https://github.com/autotelic/fastify-opentelemetry/runs/7963898090?check_suite_focus=true#step:5:31
   - Previously: https://github.com/autotelic/fastify-opentelemetry/runs/6891777049?check_suite_focus=true#step:5:30
   - No changes on our part aside from docs update
   - Was able to reproduce locally, but only on Node v14
- Looks like we missed adding an `await` to the `fastify.register` call in our `setupTests` function
  - Updating this fixed the issue 
  - Not sure why this didn't cause an issue when we first updated to Fastify v4 (#46 )
- Updated validate workflow to run tests on Node v14 as well as v16
- Updated `tap` to latest version

### Test plan

 - Confirm validate workflow passes 
