### PR TITLE
Fix fastify v4 support by upgrading to fastify-plugin@^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.0"
+    "fastify-plugin": "^4.0.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
This package currently relies on `fastify-plugin@^3.0.`0 which isn't supported by fastify 4:

> `FastifyError: fastify-plugin: fastify-opentelemetry - expected '3.x' fastify version, '4.9.2' is installed`

upgrading to `fastify-plugin@^4.0.0` should fix this