### PR TITLE
Use more compatible default export ts syntax

### DIFF
--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -35,4 +35,4 @@ export interface OpenTelemetryPluginOptions {
 
 declare const fastifyOpenTelemetry: FastifyPluginCallback<OpenTelemetryPluginOptions>
 
-export default fastifyOpenTelemetry
+export = fastifyOpenTelemetry


### PR DESCRIPTION
Changing the `.d.ts` file default export syntax to be more compatible.

https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html#default-exports

> Note that using export default in your .d.ts files requires esModuleInterop: true to work. If you can’t have esModuleInterop: true in your project, such as when you’re submitting a PR to Definitely Typed, you’ll have to use the export= syntax instead. This older syntax is harder to use but works everywhere. Here’s how the above example would have to be written using export=: