### PR TITLE
fix: use request.routeOptions instead of deprecated request.routerPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,14 @@ const {
 const { name: moduleName, version: moduleVersion } = require('./package.json')
 
 function defaultFormatSpanName (request) {
-  const { method, routerPath } = request
-  return routerPath ? `${method} ${routerPath}` : method
+  const { method } = request
+  let path
+  if (request.routeOptions) {
+    path = request.routeOptions.url
+  } else {
+    path = request.routerPath
+  }
+  return path ? `${method} ${path}` : method
 }
 
 const defaultFormatSpanAttributes = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -418,3 +418,37 @@ test('should use router path in span name', async ({ same, teardown }) => {
     'should not contain router path when no matching routes found'
   )
 })
+
+test('should use request.routerPath if request.routeOptions does not exist', async ({ same, teardown }) => {
+  const fastify = await setupTest({})
+  fastify.decorateRequest('routeOptions', {
+    getter () {
+      return undefined
+    }
+  })
+
+  const activeContext = stub(context, 'active').returns({
+    getValue: () => STUB_SPAN,
+    setValue: () => null
+  })
+
+  teardown(() => {
+    activeContext.restore()
+    resetHistory()
+    fastify.close()
+  })
+
+  await fastify.inject(injectArgs)
+  await fastify.inject({ ...injectArgs, url: '/invalid' })
+
+  same(
+    STUB_TRACER.startSpan.args[0][0],
+    'GET /test',
+    'should contain router path'
+  )
+  same(
+    STUB_TRACER.startSpan.args[1][0],
+    'GET',
+    'should not contain router path when no matching routes found'
+  )
+})


### PR DESCRIPTION
`request.routerPath` was deprecated in fastify@4.23.0. Since then it produces the following warning:

```
[FSTDEP017] FastifyDeprecation: You are accessing the deprecated "request.routerPath" property. Use "request.routeOptions.url" instead. Property "req.routerPath" will be removed in `fastify@5`
```

`request.routeOptions` was added in fastify@4.10.0. This approach supports backward compatibility while also avoiding accessing `request.routerPath` in case of a 404 in versions prior to 4.10.0.

Prior to this change, the test suite emitted this warning 11 times. It is now emitted once, only for the new test which covers the case in which `request.routeOptions` does not exist.

See also open-telemetry/opentelemetry-js-contrib#1757