### PR TITLE
fix: wrapped route handlers were forced to be async or return a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
 
   if (wrapRoutes) {
     function wrapRoute (routeHandler) {
-      return async function (request, ...args) {
+      return function (request, ...args) {
         const reqContext = getContext(request)
         return context.with(reqContext, routeHandler.bind(this, request, ...args))
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -199,10 +199,12 @@ test('should wrap all routes when wrapRoutes is true', async ({ equal, same, tea
 
   await fastify.register(openTelemetryPlugin, { wrapRoutes: true })
 
-  async function testHandlerOne (request, reply) {
+  function testHandlerOne (request, reply) {
     request.openTelemetry()
     reply.headers({ one: 'ok' })
-    return { body: 'one' }
+    setTimeout(() => {
+      reply.send({ body: 'one' })
+    }, 0)
   }
 
   async function testHandlerTwo (request, reply) {


### PR DESCRIPTION
I encountered [this issue](https://github.com/fastify/fastify-static/issues/434) when using along side `@fastify/static`