### PR TITLE
feat: fastify v5 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20
           registry-url: 'https://registry.npmjs.org/'
       - run: npm publish --access public
         env:

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,14 +3,11 @@ on: [pull_request, workflow_call]
 jobs:
   validate:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [16, 18, 20]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           registry-url: 'https://registry.npmjs.org/'
-          node-version: ${{ matrix.node }}
+          node-version: 20
       - run: npm install
       - run: npm run validate

--- a/example/index.js
+++ b/example/index.js
@@ -19,34 +19,10 @@ const start = async () => {
       const activityRes = await fetch(`${boredApi}/api/activity`)
       // Spans started in a wrapped route will automatically be children of the activeSpan.
       childSpan = tracer.startSpan('preparing content')
-      const { activity } = await activityRes.json()
-      reply.type('text/html')
-      return `<h1>Bored?</h1><h3>Have you tried to ${activity.toLowerCase()}</h3>`
-    } catch (error) {
-      // fastify-opentelemetry automatically adds error data to the parent spans attributes.
-      return error
-    } finally {
-      // Always be sure to end child spans.
-      if (childSpan) childSpan.end()
-    }
-  })
-
-  fastify.get('/:type', async function routeHandler (request, reply) {
-    const { tracer } = request.openTelemetry()
-    let childSpan
-    try {
-      // @opentelemetry/instrumentation-http will automatically trace incoming and out going http/https requests.
-      const activityRes = await fetch(
-        `${boredApi}/api/activity?type=${request.params.type}`
-      )
-      // Spans started in a wrapped route will automatically be children of the activeSpan.
-      childSpan = tracer.startSpan(`preparing content of ${request.params.type}`)
-      const { activity, error } = await activityRes.json()
-
-      if (error) {
-        throw error
+      if (!activityRes.ok) {
+        throw Error('Something went wrong...')
       }
-
+      const { activity } = await activityRes.json()
       reply.type('text/html')
       return `<h1>Bored?</h1><h3>Have you tried to ${activity.toLowerCase()}</h3>`
     } catch (error) {

--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
 import { Context, Span, Attributes, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
 
 /**
@@ -38,7 +38,7 @@ declare namespace fastifyOpenTelemetry {
     propagateToReply?: boolean,
   }
 
-  export const fastifyOpenTelemetry: FastifyPluginCallback<OpenTelemetryPluginOptions>
+  export const fastifyOpenTelemetry: FastifyPluginAsync<OpenTelemetryPluginOptions>
 
   export { fastifyOpenTelemetry as default }
 }

--- a/index.js
+++ b/index.js
@@ -11,14 +11,7 @@ const {
 const { name: moduleName, version: moduleVersion } = require('./package.json')
 
 function defaultFormatSpanName (request) {
-  const { method } = request
-  let path
-  if (request.routeOptions) {
-    path = request.routeOptions.url
-  } else {
-    path = request.routerPath
-  }
-  return path ? `${method} ${path}` : method
+  return `${request.method} ${request.routeOptions.url || ''}`.trim()
 }
 
 const defaultFormatSpanAttributes = {
@@ -163,6 +156,6 @@ async function openTelemetryPlugin (fastify, opts = {}) {
 }
 
 module.exports = fp(openTelemetryPlugin, {
-  fastify: '4.x',
+  fastify: '4.10.x - 5.x',
   name: 'fastify-opentelemetry'
 })

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/autotelic/fastify-opentelemetry#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
@@ -51,7 +51,7 @@
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-n": "^16.2.0",
     "eslint-plugin-promise": "^6.1.1",
-    "fastify": "^4.0.0",
+    "fastify": "^5.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^15.0.2",
     "sinon": "^17.0.1",
@@ -63,7 +63,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.0.0"
+    "fastify-plugin": "^5.0.0"
   },
   "lint-staged": {
     "*.{js,ts}": [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -401,42 +401,8 @@ test('should preserve this binding in handler using wrapRoutes', async ({ equal,
   })
 })
 
-test('should use router path in span name', async ({ same, teardown }) => {
+test('should use request.routerOptions.url in defaultFormatSpanName', async ({ same, teardown }) => {
   const fastify = await setupTest({})
-
-  const activeContext = stub(context, 'active').returns({
-    getValue: () => STUB_SPAN,
-    setValue: () => null
-  })
-
-  teardown(() => {
-    activeContext.restore()
-    resetHistory()
-    fastify.close()
-  })
-
-  await fastify.inject(injectArgs)
-  await fastify.inject({ ...injectArgs, url: '/invalid' })
-
-  same(
-    STUB_TRACER.startSpan.args[0][0],
-    'GET /test',
-    'should contain router path'
-  )
-  same(
-    STUB_TRACER.startSpan.args[1][0],
-    'GET',
-    'should not contain router path when no matching routes found'
-  )
-})
-
-test('should use request.routerPath if request.routeOptions does not exist', async ({ same, teardown }) => {
-  const fastify = await setupTest({})
-  fastify.decorateRequest('routeOptions', {
-    getter () {
-      return undefined
-    }
-  })
 
   const activeContext = stub(context, 'active').returns({
     getValue: () => STUB_SPAN,

--- a/test/types/fastify-opentelemetry.test-d.ts
+++ b/test/types/fastify-opentelemetry.test-d.ts
@@ -35,7 +35,7 @@ expectType(<OpenTelemetryPluginOptions>({
     },
     reply: reply => {
       return {
-        responseTime: reply.getResponseTime()
+        responseTime: reply.elapsedTime
       }
     },
     error: error => {


### PR DESCRIPTION
### Summary
 - Closes #71 
 - Updated the Fastify version range passed into `fastify-plugin` to `4.10.x - 5.x`
 - Removed `request.routerPath` fallback usage
   - `request.routeOptions` was added in Fastify v4.10.0 - hence the new minimum Fastify version for this plugin
 - Bumped `fastify-plugin` to v5 
 - Updated example app

### BREAKING CHANGES:
* minimum fastify version of 4.10.0 is now required