### PR TITLE
feat: configurable spanOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The plugin accepts the the following configuration properties:
 
 - **`propagateToReply` : `boolean`** - When `true`, the current span context will be injected into the reply headers using your registered propagators. Defaults to `false`.
 
+- **`spanOptions` : `SpanOptions | (FastifyRequest) => SpanOptions`** - [`SpanOptions`] or a function that returns [`SpanOptions`]. These will be passed into `tracer.startSpan` on each request. Defaults to `{ kind: 1 }`.
+
 ### Request Decorator
 
 This plugin decorates the request with an `openTelemetry` function that returns an object with the following properties:
@@ -202,3 +204,4 @@ Each version of the OpenTelemetry API will require a specific release of fastify
 [`defaultTextMapSetter`]: https://open-telemetry.github.io/opentelemetry-js/globals.html#defaulttextmapsetter
 [OpenTelemetry instrumentations]: https://github.com/open-telemetry/opentelemetry-js#node-instrumentations--plugins
 [`AsyncHooksContextManager`]: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks
+[`SpanOptions`]: https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/trace/SpanOptions.ts

--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -1,5 +1,5 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify'
-import { Context, Span, Attributes, TextMapGetter, TextMapSetter, Tracer } from '@opentelemetry/api'
+import { Context, Span, Attributes, TextMapGetter, TextMapSetter, Tracer, SpanOptions } from '@opentelemetry/api'
 
 /**
  * Object exposed as part of the "openTelemetry" object on the fastify request.
@@ -33,6 +33,7 @@ declare namespace fastifyOpenTelemetry {
       reply?: (reply: FastifyReply) => Attributes,
       error?: (error: Error) => Attributes,
     },
+    spanOptions?: SpanOptions | ((request: FastifyRequest) => SpanOptions)
     wrapRoutes?: boolean | string[],
     ignoreRoutes?: string[] | ((path: string, method: string) => boolean),
     propagateToReply?: boolean,

--- a/test/types/fastify-opentelemetry.test-d.ts
+++ b/test/types/fastify-opentelemetry.test-d.ts
@@ -44,6 +44,7 @@ expectType(<OpenTelemetryPluginOptions>({
       }
     }
   },
+  spanOptions: () => ({ kind: 1 }),
   ignoreRoutes: (path: string, method: string) => method === 'OPTIONS',
   formatSpanName: (request: FastifyRequest) => `${request.method} constant-part`,
   wrapRoutes: true,


### PR DESCRIPTION
### Summary
 - Closes #69 
 - Add `spanOptions` to plugin opts
   - Can be a [SpanOptions](https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/trace/SpanOptions.ts) object or a function that returns a [SpanOptions](https://github.com/open-telemetry/opentelemetry-js/blob/main/api/src/trace/SpanOptions.ts) object
   - The default `spanOptions` has been set to `{ kind: SpanKind.SERVER }`