### PR TITLE
fix: type defs esm compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,12 +4,12 @@
   "overrides": [{
     "files": ["*.ts"],
     "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/eslint-recommended",
-      "plugin:@typescript-eslint/recommended",
-      "standard"
+      "plugin:@typescript-eslint/recommended"
     ],
     "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint"]
+    "plugins": ["@typescript-eslint"],
+    "rules": {
+      "no-use-before-define": "off"
+    }
   }]
 }

--- a/fastify-opentelemetry.d.ts
+++ b/fastify-opentelemetry.d.ts
@@ -12,6 +12,8 @@ type ReqInstance = {
   extract: <Carrier> (carrier: Carrier, getter?: TextMapGetter) => Context,
 }
 
+type FastifyOpenTelemetry = FastifyPluginAsync<fastifyOpenTelemetry.OpenTelemetryPluginOptions>
+
 declare module 'fastify' {
   interface FastifyRequest {
     openTelemetry: () => ReqInstance
@@ -39,9 +41,11 @@ declare namespace fastifyOpenTelemetry {
     propagateToReply?: boolean,
   }
 
-  export const fastifyOpenTelemetry: FastifyPluginAsync<OpenTelemetryPluginOptions>
+  export const fastifyOpenTelemetry: FastifyOpenTelemetry
 
   export { fastifyOpenTelemetry as default }
 }
+
+declare function fastifyOpenTelemetry(...params: Parameters<FastifyOpenTelemetry>): ReturnType<FastifyOpenTelemetry>
 
 export = fastifyOpenTelemetry

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@autotelic/fastify-opentelemetry",
   "version": "0.22.0",
   "description": "A Fastify plugin for OpenTelemetry",
+  "type": "commonjs",
   "main": "index.js",
   "files": [
     "fastify-opentelemetry.d.ts"


### PR DESCRIPTION
### Summary

 - Resolves  #74 

### Test plan

- View debug repo -> https://github.com/HW13/fastify-otel-ts-debug
- Build was failing after switching to `"type": "module"` -> https://github.com/HW13/fastify-otel-ts-debug/commit/14dfc00bb9f4bf3a5a4f437d80feaa26c355a886
- Build passes after [yalc](https://github.com/wclr/yalc) adding this branch -> https://github.com/HW13/fastify-otel-ts-debug/commit/3d1c26c240c31529e3f9dfc24f4850970efcc2ff