### PR TITLE
Set SpanStatusCode.ERROR if statusCode >= 500 to align with the latest specs

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ async function openTelemetryPlugin (fastify, opts = {}) {
     const span = trace.getSpan(activeContext)
     const spanStatus = { code: SpanStatusCode.OK }
 
-    if (reply.statusCode >= 400) {
+    if (reply.statusCode >= 500) {
       spanStatus.code = SpanStatusCode.ERROR
     }
 


### PR DESCRIPTION
According to latest Opentelemetry specs: 

> For HTTP status codes in the 4xx range span status MUST be left unset in case of SpanKind.SERVER and SHOULD be set to Error in case of SpanKind.CLIENT.
> 
> For HTTP status codes in the 5xx range, as well as any other code the client failed to interpret, span status SHOULD be set to Error.

https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status